### PR TITLE
Custom ids

### DIFF
--- a/index.html
+++ b/index.html
@@ -94,9 +94,15 @@
 					</button>
 				</div>
 
-				<div class="col-3">
+				<div class="col-auto">
 					<button class="btn btn-primary" id="sync-local-storage-button">
 						Sync local storage data
+					</button>
+				</div>
+
+				<div class="col-auto">
+					<button class="btn btn-primary" id="chars-icons-switch-button">
+						Chars <i class="fas fa-exchange-alt px-2"></i> Icons
 					</button>
 				</div>
 			</div>

--- a/index.html
+++ b/index.html
@@ -44,9 +44,9 @@
 						New Id
 					</button>
 				</div>
-        <div class="col-auto">
-          <div id="qrcode"></div>
-        </div>
+				<div class="col-auto">
+					<div id="qrcode"></div>
+		        </div>
 			</div>
 
 			<div class="row pt-2">

--- a/index.html
+++ b/index.html
@@ -68,7 +68,7 @@
 				</div>
 
 				<div class="col-auto">
-					<button type="button" class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#enterNewPeerIdModal">
+					<button type="button" class="btn btn-primary" id="enter-existing-id-button" data-bs-toggle="modal" data-bs-target="#enterNewPeerIdModal">
 						<i class="fas fa-edit"></i>
 						Enter Id
 					</button>
@@ -115,7 +115,7 @@
 						<button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
 					</div>
 					<div class="modal-body">
-						<input type="text" class="form-control" id="new-peer-id-input" placeholder="00000000-0000-0000-0000-000000000000">
+						<div id="enter-peer-id-modal-content"></div>
 					</div>
 					<div class="modal-footer">
 						<button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>

--- a/index.html
+++ b/index.html
@@ -12,18 +12,54 @@
         <link rel="stylesheet" href="style.css">
     </head>
     <body>
-		<div class="container">
-			<h1 class="pt-5" style="text-align: center;">PearShare</h1>
+		<div class="container pt-3">
+			<div class="row justify-content-center">
+				<div class="col-auto">
+					<h1 class="pt-5" style="text-align: center;">PearShare</h1>
+				</div>
+	
+				<div class="col-auto">
+					<div id="qrcode"></div>
+				</div>
+			</div>
 
 			<div class="row pt-5">
 				<div class="col-2" style="display: flex; justify-content: center; align-items: center;">
 					<span><b>ID:</b></span>
 				</div>
 
-				<div class="col-5">
-					<input type="text" id="peerjs-id-input" class="form-control" placeholder="could not get id from brokering server" readonly>
+				<div class="col-auto">
+					<div class="card">
+						<div class="card-body">
+							<span class="card-text" id="id-span"></span>
+						</div>
+					</div>
+				</div>				
+			</div>			
+
+			<div class="row pt-2">
+				<div class="col-2" style=" display: flex; justify-content: center; align-items: center;">
+					<span><b>Connected to:</b></span>
 				</div>
 
+				<div class="col-5">
+					<input type="text" id="connected-to-id-input" class="form-control" placeholder="not connected" readonly>
+				</div>				
+			</div>
+
+			<div class="row pt-2">
+				<div class="col-2" style=" display: flex; justify-content: center; align-items: center;">
+					<span><b>Connection id:</b></span>
+				</div>
+
+				<div class="col-5">
+					<input type="text" id="connection-id-input" class="form-control" placeholder="not connected" readonly>
+				</div>
+			</div>
+
+			<hr>
+
+			<div class="row">
 				<div class="col-auto">
 					<button class="btn btn-warning" id="status-button" disabled>
 						<i class="fas fa-exclamation-circle"></i>
@@ -44,19 +80,6 @@
 						New Id
 					</button>
 				</div>
-				<div class="col-auto">
-					<div id="qrcode"></div>
-		        </div>
-			</div>
-
-			<div class="row pt-2">
-				<div class="col-2" style=" display: flex; justify-content: center; align-items: center;">
-					<span><b>Connected to:</b></span>
-				</div>
-
-				<div class="col-5">
-					<input type="text" id="connected-to-id-input" class="form-control" placeholder="not connected" readonly>
-				</div>
 
 				<div class="col-auto">
 					<button class="btn btn-primary" id="close-connection-button">
@@ -64,22 +87,8 @@
 						Close connection
 					</button>
 				</div>
-			</div>
 
-			<div class="row pt-2">
-				<div class="col-2" style=" display: flex; justify-content: center; align-items: center;">
-					<span><b>Connection id:</b></span>
-				</div>
-
-				<div class="col-5">
-					<input type="text" id="connection-id-input" class="form-control" placeholder="not connected" readonly>
-				</div>
-			</div>
-
-			<hr>
-
-			<div class="row">
-				<div class="col-3">
+				<div class="col-auto">
 					<button class="btn btn-primary" id="write-local-storage-button">
 						Write data to local storage
 					</button>

--- a/index.js
+++ b/index.js
@@ -32,6 +32,7 @@
     var connectToastText = document.getElementById('connect-toast-text');
     var disconnectToastText = document.getElementById('disconnect-toast-text');
     var syncLocalStorageText = document.getElementById('sync-local-storage-toast-text');
+    var idSpan = document.getElementById('id-span');
 
     var toastElementList = [].slice.call(document.querySelectorAll('.toast'))
     var toastList = toastElementList.map(function (toastElement) {
@@ -44,6 +45,22 @@
     var currentlyHandledConnection = undefined;
 
     var currentConnectionAccepted = false;
+
+    var useCustomId = false;
+    var customIdCharacters = [
+        'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r', 's', 
+        't', 'u', 'v', 'w', 'x', 'y', 'z', 'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L',
+        'M', 'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z', '0', '1', '2', '3', '4', 
+        '5', '6', '7', '8', '9'];
+    var customIdIcons = [
+        'ambulance', 'anchor', 'angry', 'apple-alt', 'beer', 'bell', 'bone', 'bread-slice', 'bus', 'car', 
+        'car-side', 'cat', 'chess-knight', 'cocktail', 'coffee', 'crow', 'dizzy', 'dog', 'dove', 'dragon', 
+        'feather', 'fish', 'flushed', 'frog', 'frown', 'gas-pump', 'ghost', 'grimace', 'grin', 'grin-beam', 
+        'grin-squint', 'grin-squint-tears', 'grin-tears', 'grin-tongue', 'grin-tongue-wink', 'hamburger', 
+        'hand-point-left', 'hand-point-right', 'handshake', 'heart', 'hippo', 'horse', 'ice-cream', 'kiss', 
+        'kiwi-bird', 'laugh-wink', 'meh', 'meh-blank', 'meh-rolling-eyes', 'motorcycle', 'otter', 'paw', 
+        'phone', 'pizza-slice', 'smile', 'spider', 'surprise', 'thumbs-down', 'thumbs-up', 'truck', 
+        'wheelchair', 'wine-bottle']
 
 
     function initialize() {
@@ -126,7 +143,7 @@
                 lastPeerId = peer.id;
             }
 
-            idInput.value = `${peer.id}`;
+            idSpan.innerHTML = getIdAsHtmlContent();
             generateQRCode();
             handleUrlQueryParams();
         });
@@ -388,10 +405,38 @@
             correctLevel : QRCode.CorrectLevel.H
         });
     }
+
     function generateQRCode() {
         const currentUrl = window.location.href.split('?')[0]
         qrcode.clear()
         qrcode.makeCode(currentUrl +"?peer_id=" +peer.id)
+    }
+
+    function getIdAsHtmlContent() {
+
+        if (useCustomId) {
+            const characters = [...peer.id];
+
+            let icons = '';
+
+            characters.forEach(c => {
+                const icon = getIconFromCharacter(c);
+
+                icons += icon;
+            });
+
+            return icons;
+        }
+
+        return `${peer.id}`;
+    }
+
+    function getIconFromCharacter(character) {
+        const characterIndex = customIdCharacters.indexOf(character);
+
+        var icon = `<i class="fas fa-${customIdIcons[characterIndex]} fa-2x px-2"></i>`;
+        
+        return icon;
     }
 
     initialize();

--- a/index.js
+++ b/index.js
@@ -21,6 +21,8 @@
     var closeConnectionButton = document.getElementById('close-connection-button');
     var writeToLocalStorageButton = document.getElementById('write-local-storage-button');
     var syncToLocalStorageButton = document.getElementById('sync-local-storage-button');
+    var charsIconsSwitchButton = document.getElementById('chars-icons-switch-button');
+    
 
     var newPeerIdModal = new bootstrap.Modal(document.getElementById('enterNewPeerIdModal'));
     var acceptIncomingConnectionModal = new bootstrap.Modal(document.getElementById('acceptIncomingConnectionModal'));
@@ -87,7 +89,8 @@
             host: peerJsHost,
             port: peerJsPort,
             path: peerJsPath,
-            debug: 2
+            debug: 2,
+            useCustomId: useCustomId,
         });
 
         setPeerListeners(peer);
@@ -307,6 +310,12 @@
                 syncLocalStorageText.innerHTML = `Synced local storage with ${connection.peer}.`;
                 toastList[2].show();
             }
+        });
+
+        charsIconsSwitchButton.addEventListener('click', function () {
+            useCustomId = !useCustomId;
+
+            getNewPeer();
         });
     }
 

--- a/index.js
+++ b/index.js
@@ -93,7 +93,7 @@
             port: peerJsPort,
             path: peerJsPath,
             debug: 2,
-            //useCustomId: useCustomId,
+            useCustomId: useCustomId,
         });
 
         setPeerListeners(peer);

--- a/index.js
+++ b/index.js
@@ -49,7 +49,7 @@
 
     var currentConnectionAccepted = false;
 
-    var useCustomId = true;
+    var useCustomId = false;
     var customIdCharacters = [
         'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r', 's', 
         't', 'u', 'v', 'w', 'x', 'y', 'z', 'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L',

--- a/index.js
+++ b/index.js
@@ -65,6 +65,8 @@
         'phone', 'pizza-slice', 'smile', 'spider', 'surprise', 'thumbs-down', 'thumbs-up', 'truck', 
         'wheelchair', 'wine-bottle']
 
+    var enteredEmojiCharacters = '';
+
 
     function initialize() {
         getNewPeer();
@@ -259,28 +261,16 @@
         });
 
         enterExistingIdButton.addEventListener('click', function () {
-            let content = '';
 
             if (useCustomId) {
 
-                content += ' \
-                <div class="row row-cols-5">';
-
-                customIdCharacters.forEach(c => {
-                    content += ' <div class="col">';
-                    content += '<button type="button" class="btn btn-secondary my-1" name="emojiKeyboard" style="width: 5rem">';
-                    content += getIconFromCharacter(c);
-                    content += '</button>';
-                    content += '</div>'
-                });
-
-                content += '</div>';
+                buildEmojiKeyboard();
 
             } else {
-                content = '<input type="text" class="form-control" id="new-peer-id-input" placeholder="00000000-0000-0000-0000-000000000000">';
+                const content = '<input type="text" class="form-control" id="new-peer-id-input" placeholder="00000000-0000-0000-0000-000000000000">';
+                enterPeerIdModalContent.innerHTML = content;
             }
 
-            enterPeerIdModalContent.innerHTML = content;
         });
 
         acceptIncomingConnectionButton.addEventListener('click', function () {
@@ -349,6 +339,37 @@
             useCustomId = !useCustomId;
 
             getNewPeer();
+        });
+    }
+
+    function buildEmojiKeyboard() {
+        let content = '<div class="row row-cols-5">';
+
+        customIdCharacters.forEach(c => {
+            content += '<div class="col">';
+            content += '<button type="button" class="btn btn-secondary my-1" name="emojiKeyboardButton" style="width: 5rem">';
+            content += getIconFromCharacter(c);
+            content += '</button>';
+            content += '</div>'
+        });
+
+        content += '</div>';
+
+        enteredEmojiCharacters = '';
+
+        enterPeerIdModalContent.innerHTML = content;
+
+        const keyboardButtons = document.getElementsByName('emojiKeyboardButton');
+
+        keyboardButtons.forEach(kb => {
+
+            const character = kb.children[0].attributes.getNamedItem('char').nodeValue;
+
+            kb.addEventListener('click', function (event) {
+                enteredEmojiCharacters += character;
+
+                console.log(enteredEmojiCharacters);
+            });
         });
     }
 
@@ -476,7 +497,7 @@
     function getIconFromCharacter(character) {
         const characterIndex = customIdCharacters.indexOf(character);
 
-        var icon = `<i class="fas fa-${customIdIcons[characterIndex]} fa-2x px-2"></i>`;
+        var icon = `<i class="fas fa-${customIdIcons[characterIndex]} fa-2x px-2" char="${character}"></i>`;
         
         return icon;
     }

--- a/index.js
+++ b/index.js
@@ -8,7 +8,6 @@
     var peer = null; // own peer object
     var connection = null;
 
-    var idInput = document.getElementById('peerjs-id-input');
     var newPeerIdInput = document.getElementById('new-peer-id-input');
     var connectedToIdInput = document.getElementById('connected-to-id-input');
     var connectionIdInput = document.getElementById('connection-id-input');
@@ -132,7 +131,7 @@
 
         currentlyHandledConnection = newConnection;
 
-        acceptIncomingConnectionText.innerHTML = `Accept connection with ${newConnection.peer}?`;
+        acceptIncomingConnectionText.innerHTML = `Accept connection with <br>${getIdAsHtmlContent(newConnection.peer)}?`;
         acceptIncomingConnectionModal.show();
     }
 
@@ -146,7 +145,7 @@
                 lastPeerId = peer.id;
             }
 
-            idSpan.innerHTML = getIdAsHtmlContent();
+            idSpan.innerHTML = getIdAsHtmlContent(peer.id);
             generateQRCode();
             handleUrlQueryParams();
         });
@@ -421,10 +420,10 @@
         qrcode.makeCode(currentUrl +"?peer_id=" +peer.id)
     }
 
-    function getIdAsHtmlContent() {
+    function getIdAsHtmlContent(id) {
 
         if (useCustomId) {
-            const characters = [...peer.id];
+            const characters = [...id];
 
             let icons = '';
 

--- a/index.js
+++ b/index.js
@@ -77,7 +77,7 @@
     function handleUrlQueryParams() {
         const urlParams = new URLSearchParams(window.location.search);
         const connectionPeerId = urlParams.get("peer_id");
-        console.log(connectionPeerId);
+        
         if (connectionPeerId !== null) {
             connectToExistingPeer(connectionPeerId);
         }
@@ -251,7 +251,7 @@
             let peerId = '';
 
             if (useCustomId) {
-
+                peerId = enteredEmojiCharacters;
             } else {
                 const newPeerIdInput = document.getElementById('new-peer-id-input');
                 peerId = newPeerIdInput.value;
@@ -343,7 +343,16 @@
     }
 
     function buildEmojiKeyboard() {
-        let content = '<div class="row row-cols-5">';
+        let content = '';
+
+        content += '\
+            <div class="card">\
+                <div class="card-body">\
+                    <span class="card-text" id="entered-id-span"></span>\
+                </div>\
+            </div>';
+
+        content += '<div class="row row-cols-5">';
 
         customIdCharacters.forEach(c => {
             content += '<div class="col">';
@@ -359,16 +368,19 @@
 
         enterPeerIdModalContent.innerHTML = content;
 
+        const enteredIdSpan = document.getElementById('entered-id-span');
+        enteredIdSpan.innerHTML = " ";
+
         const keyboardButtons = document.getElementsByName('emojiKeyboardButton');
 
         keyboardButtons.forEach(kb => {
 
             const character = kb.children[0].attributes.getNamedItem('char').nodeValue;
 
-            kb.addEventListener('click', function (event) {
+            kb.addEventListener('click', function () {
                 enteredEmojiCharacters += character;
 
-                console.log(enteredEmojiCharacters);
+                enteredIdSpan.innerHTML = getIdAsHtmlContent(enteredEmojiCharacters);
             });
         });
     }

--- a/index.js
+++ b/index.js
@@ -8,7 +8,6 @@
     var peer = null; // own peer object
     var connection = null;
 
-    var newPeerIdInput = document.getElementById('new-peer-id-input');
     var connectedToIdInput = document.getElementById('connected-to-id-input');
     var connectionIdInput = document.getElementById('connection-id-input');
 
@@ -21,6 +20,7 @@
     var writeToLocalStorageButton = document.getElementById('write-local-storage-button');
     var syncToLocalStorageButton = document.getElementById('sync-local-storage-button');
     var charsIconsSwitchButton = document.getElementById('chars-icons-switch-button');
+    var enterExistingIdButton = document.getElementById('enter-existing-id-button');
     
 
     var newPeerIdModal = new bootstrap.Modal(document.getElementById('enterNewPeerIdModal'));
@@ -35,6 +35,8 @@
     var syncLocalStorageText = document.getElementById('sync-local-storage-toast-text');
     var idSpan = document.getElementById('id-span');
 
+    var enterPeerIdModalContent = document.getElementById('enter-peer-id-modal-content');
+
     var toastElementList = [].slice.call(document.querySelectorAll('.toast'))
     var toastList = toastElementList.map(function (toastElement) {
         return new bootstrap.Toast(toastElement)
@@ -47,7 +49,7 @@
 
     var currentConnectionAccepted = false;
 
-    var useCustomId = false;
+    var useCustomId = true;
     var customIdCharacters = [
         'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r', 's', 
         't', 'u', 'v', 'w', 'x', 'y', 'z', 'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L',
@@ -89,7 +91,7 @@
             port: peerJsPort,
             path: peerJsPath,
             debug: 2,
-            useCustomId: useCustomId,
+            //useCustomId: useCustomId,
         });
 
         setPeerListeners(peer);
@@ -244,9 +246,41 @@
         submitNewPeerIdButton.addEventListener('click', function () {
             newPeerIdModal.hide();
 
-            const peerId = newPeerIdInput.value;
+            let peerId = '';
+
+            if (useCustomId) {
+
+            } else {
+                const newPeerIdInput = document.getElementById('new-peer-id-input');
+                peerId = newPeerIdInput.value;
+            }
 
             connectToExistingPeer(peerId);
+        });
+
+        enterExistingIdButton.addEventListener('click', function () {
+            let content = '';
+
+            if (useCustomId) {
+
+                content += ' \
+                <div class="row row-cols-5">';
+
+                customIdCharacters.forEach(c => {
+                    content += ' <div class="col">';
+                    content += '<button type="button" class="btn btn-secondary my-1" name="emojiKeyboard" style="width: 5rem">';
+                    content += getIconFromCharacter(c);
+                    content += '</button>';
+                    content += '</div>'
+                });
+
+                content += '</div>';
+
+            } else {
+                content = '<input type="text" class="form-control" id="new-peer-id-input" placeholder="00000000-0000-0000-0000-000000000000">';
+            }
+
+            enterPeerIdModalContent.innerHTML = content;
         });
 
         acceptIncomingConnectionButton.addEventListener('click', function () {


### PR DESCRIPTION
implemented emoji based client ids

changes:
- button to switch between standard uuid and custom emoji id (throws errors because the aws peerjs server has an old version)
- in emoji id mode ids are displayed as fontawesome icons (technically they are strings)
- emoji keyboard to enter an existing emoji id
- toasts can't display id's as emojis
- layout fixes
- ui design is atrocious 👍

for tests:
- set useCustomId in line 52 to true
- add comment to line 96